### PR TITLE
Documentation changes, proposed function renaming

### DIFF
--- a/CAJAL/lib/calculate_gw_pairwise.py
+++ b/CAJAL/lib/calculate_gw_pairwise.py
@@ -6,7 +6,7 @@ from CAJAL.lib import run_gw
 
 def run_euclidean(data_dir, gw_results_dir, data_prefix, num_cores, file_prefix):
     t1 = time.time()
-    dist_mat_list = run_gw.get_distances_all(data_dir=data_dir, data_prefix=data_prefix)
+    dist_mat_list = run_gw.get_intracell_distances_all(data_dir=data_dir, data_prefix=data_prefix)
     run_gw.save_dist_mat_preload_global(dist_mat_list, file_prefix, gw_results_dir,
                                         save_mat=False, num_cores=num_cores)
     t3 = time.time()

--- a/CAJAL/lib/calculate_gw_pairwise.py
+++ b/CAJAL/lib/calculate_gw_pairwise.py
@@ -15,7 +15,7 @@ def run_euclidean(data_dir, gw_results_dir, data_prefix, num_cores, file_prefix)
 
 def run_geodesic(distances_dir, gw_results_dir, data_prefix, num_cores, file_prefix):
     t1 = time.time()
-    dist_mat_list = run_gw.load_distances_global(distances_dir=distances_dir, data_prefix=data_prefix)
+    dist_mat_list = run_gw.load_intracell_distances(distances_dir=distances_dir, data_prefix=data_prefix)
     run_gw.save_dist_mat_preload_global(dist_mat_list, file_prefix, gw_results_dir, save_mat=False,
                                         num_cores=num_cores)
     t3 = time.time()

--- a/CAJAL/lib/run_gw.py
+++ b/CAJAL/lib/run_gw.py
@@ -24,7 +24,7 @@ TODO:
 '''
 
 
-def get_distances_one(data_file, metric="euclidean", return_mp=True, header=None):
+def get_intracell_distances_one(data_file, metric="euclidean", return_mp=True, header=None):
     """
     Compute the pairwise distances in the point cloud stored in the file.
     Return distance matrix as numpy array or mp (multiprocessing) array
@@ -89,7 +89,7 @@ def get_distances_one(data_file, metric="euclidean", return_mp=True, header=None
 #     return outfile
 
 
-def get_distances_all(data_dir, data_prefix=None, data_suffix="csv",
+def get_intracell_distances_all(data_dir, data_prefix=None, data_suffix="csv",
                       #distances_dir=None,
                       metric="euclidean", return_mp=True, header=None):
     """
@@ -120,10 +120,10 @@ def get_distances_all(data_dir, data_prefix=None, data_suffix="csv",
     # if distances_dir is not None and not os.path.exists(distances_dir):
     #     os.makedirs(distances_dir)
 
-    files_list = list_sort_files(data_dir, data_prefix)
+    files_list = list_sort_files(data_dir, data_prefix, data_suffix=data_suffix)
     
     # Compute pairwise distance between points in each file
-    return_list = [get_distances_one(pj(data_dir, data_file), metric=metric, return_mp=return_mp, header=header)
+    return_list = [get_intracell_distances_one(pj(data_dir, data_file), metric=metric, return_mp=return_mp, header=header)
                    for data_file in files_list]
     check_num_pts = all([len(x) == len(return_list[0]) for x in return_list])
     if not check_num_pts:

--- a/CAJAL/lib/run_gw.py
+++ b/CAJAL/lib/run_gw.py
@@ -188,10 +188,10 @@ def init_fn(dist_mat_list_, save_mat):
     return_mat = save_mat
 
 
-def distance_matrix_preload_global(dist_mat_list_, save_mat=False, num_cores=12, chunk_size=100):
+def compute_GW_distance_matrix_preload_global(dist_mat_list_, save_mat=False, num_cores=12, chunk_size=100):
     """
-    Calculate the GW distance between every pair of distance matrices
-    
+    Compute the GW distance between every pair of matrices in a given list of intracell distance matrices
+        
     Args:
         dist_mat_list_ (list): list of multiprocessing or numpy arrays containing distance matrix for each cell
         save_mat (boolean): if True, returns coupling matrix (matching) between points
@@ -201,7 +201,7 @@ def distance_matrix_preload_global(dist_mat_list_, save_mat=False, num_cores=12,
             larger size is faster but takes more memory, see multiprocessing pool.imap() for details
     
     Returns:
-        None (writes distance matrix of GW distances to file)
+        A GW distance matrix of the GW distances between all the intracell distance matrices in dist_mat_list_.
     """
     arguments = it.combinations(range(len(dist_mat_list_)), 2)
 
@@ -218,13 +218,15 @@ def distance_matrix_preload_global(dist_mat_list_, save_mat=False, num_cores=12,
     return dist_results
 
 
-def save_dist_mat_preload_global(dist_mat_list_, file_prefix, gw_results_dir,
+def compute_and_save_GW_dist_mat(dist_mat_list_, file_prefix, gw_results_dir,
                                  save_mat=False, num_cores=12, chunk_size=100):
     """
-    Save the GW distance between each pair of distance matrices in vector form
+    
+    Compute the GW distance between each pair of distance matrices in vector form,
+    and write the resulting matrix of GW distances to a file.
 
     Args:
-        dist_mat_list_ (list): list of multiprocessing or numpy arrays containing distance matrix for each cell
+        dist_mat_list_ (list): list of multiprocessing or numpy arrays containing intracell distance matrix for each cell
         file_prefix (string): name of output file to write GW distance matrix to
         gw_results_dir (string): path to directory to write output file to
         save_mat (boolean): if True, returns coupling matrix (matching) between points
@@ -240,7 +242,7 @@ def save_dist_mat_preload_global(dist_mat_list_, file_prefix, gw_results_dir,
     if not os.path.exists(gw_results_dir):
         os.makedirs(gw_results_dir)
 
-    dist_results = distance_matrix_preload_global(dist_mat_list_, save_mat=save_mat,
+    dist_results = compute_GW_distance_matrix_preload_global(dist_mat_list_, save_mat=save_mat,
                                                   num_cores=num_cores, chunk_size=chunk_size)
 
     # Save results - suffix name of output files is currently hardcoded

--- a/CAJAL/lib/run_gw.py
+++ b/CAJAL/lib/run_gw.py
@@ -131,7 +131,7 @@ def get_intracell_distances_all(data_dir, data_prefix=None, data_suffix="csv",
     return return_list
 
 
-def load_distances_global(distances_dir, data_prefix=None, return_mp=True):
+def load_intracell_distances(distances_dir, data_prefix=None, return_mp=True):
     """
     Load distance matrices from directory into list of arrays
     that can be shared with the multiprocessing pool.

--- a/CAJAL/lib/sample_swc.py
+++ b/CAJAL/lib/sample_swc.py
@@ -404,8 +404,9 @@ def save_sample_pts_parallel(infolder, outfolder, types_keep=(0, 1, 2, 3, 4),
     Parallelize sampling the same number of points from all SWC files in a folder
 
     Args:
-        infolder (string): path to folder containing SWC files
-        outfolder (string): path to output folder to save distance vectors
+        infolder (string): path to folder containing SWC files. Only files ending in ".SWC" or ".swc" will be
+        processed; other files will be ignored with a warning.
+        outfolder (string): path to output folder to save *.csv files.
         types_keep (tuple,list): list of SWC neuron part types to sample points from
             by default, uses only 1 (soma), 2 (axon), 3 (basal dendrite), 4 (apical dendrite)
         goal_num_pts (integer): number of points to sample

--- a/notebooks/save_gw_neurons.ipynb
+++ b/notebooks/save_gw_neurons.ipynb
@@ -50,7 +50,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Total time elapsed: 42.702s\n"
+      "Total time elapsed: 46.466s\n"
      ]
     }
    ],
@@ -89,9 +89,9 @@
      "text": [
       "Calculating distances between points in each dataset\n",
       "Calculating GW distances between datasets\n",
-      "Time to compute distances: 0.183s\n",
-      "Time in GW calculation: 6.875s\n",
-      "Total time elapsed: 7.058s\n"
+      "Time to compute distances: 0.192s\n",
+      "Time in GW calculation: 7.003s\n",
+      "Total time elapsed: 7.195s\n"
      ]
     }
    ],
@@ -102,7 +102,7 @@
     "dist_mat_list = run_gw.get_intracell_distances_all(data_dir=data_dir, data_prefix=data_prefix)\n",
     "t2 = time.time()\n",
     "print(\"Calculating GW distances between datasets\")\n",
-    "run_gw.save_dist_mat_preload_global(dist_mat_list, file_prefix, gw_results_dir, save_mat=True, num_cores=num_cores)\n",
+    "run_gw.compute_and_save_GW_dist_mat(dist_mat_list, file_prefix, gw_results_dir, save_mat=True, num_cores=num_cores)\n",
     "t3 = time.time()\n",
     "print('Time to compute distances: {:.3f}s'.format(t2 - t1))\n",
     "print('Time in GW calculation: {:.3f}s'.format(t3 - t2))\n",
@@ -125,7 +125,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Total time elapsed: 47.015s\n"
+      "Total time elapsed: 50.909s\n"
      ]
     }
    ],
@@ -155,7 +155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -164,9 +164,9 @@
      "text": [
       "Calculating distances between points in each dataset\n",
       "Calculating GW distances between datasets\n",
-      "Time to load distances: 0.052s\n",
-      "Time in GW calculation: 5.279s\n",
-      "Total time elapsed: 5.332s\n"
+      "Time to load distances: 0.082s\n",
+      "Time in GW calculation: 5.209s\n",
+      "Total time elapsed: 5.290s\n"
      ]
     }
    ],
@@ -177,7 +177,7 @@
     "dist_mat_list = run_gw.load_distances_global(distances_dir=distances_dir, data_prefix=data_prefix)\n",
     "t2 = time.time()\n",
     "print(\"Calculating GW distances between datasets\")\n",
-    "run_gw.save_dist_mat_preload_global(dist_mat_list, file_prefix, gw_results_dir, save_mat=True, num_cores=num_cores)\n",
+    "run_gw.compute_and_save_GW_dist_mat(dist_mat_list, file_prefix, gw_results_dir, save_mat=True, num_cores=num_cores)\n",
     "t3 = time.time()\n",
     "print('Time to load distances: {:.3f}s'.format(t2 - t1))\n",
     "print('Time in GW calculation: {:.3f}s'.format(t3 - t2))\n",
@@ -194,7 +194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/save_gw_neurons.ipynb
+++ b/notebooks/save_gw_neurons.ipynb
@@ -28,21 +28,21 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/conda/lib/python3.7/site-packages/CAJAL/lib/sample_swc.py:156: UserWarning: More disconnected segments in neuron than points to sample, skipping\n",
+      "/home/patn/CAJAL/CAJAL/lib/sample_swc.py:161: UserWarning: More disconnected segments in neuron than points to sample, skipping\n",
       "  warnings.warn(\"More disconnected segments in neuron than points to sample, skipping\")\n",
-      "/opt/conda/lib/python3.7/site-packages/CAJAL/lib/sample_swc.py:156: UserWarning: More disconnected segments in neuron than points to sample, skipping\n",
+      "/home/patn/CAJAL/CAJAL/lib/sample_swc.py:161: UserWarning: More disconnected segments in neuron than points to sample, skipping\n",
       "  warnings.warn(\"More disconnected segments in neuron than points to sample, skipping\")\n",
-      "/opt/conda/lib/python3.7/site-packages/CAJAL/lib/sample_swc.py:156: UserWarning: More disconnected segments in neuron than points to sample, skipping\n",
+      "/home/patn/CAJAL/CAJAL/lib/sample_swc.py:161: UserWarning: More disconnected segments in neuron than points to sample, skipping\n",
       "  warnings.warn(\"More disconnected segments in neuron than points to sample, skipping\")\n",
-      "/opt/conda/lib/python3.7/site-packages/CAJAL/lib/sample_swc.py:156: UserWarning: More disconnected segments in neuron than points to sample, skipping\n",
+      "/home/patn/CAJAL/CAJAL/lib/sample_swc.py:161: UserWarning: More disconnected segments in neuron than points to sample, skipping\n",
       "  warnings.warn(\"More disconnected segments in neuron than points to sample, skipping\")\n",
-      "/opt/conda/lib/python3.7/site-packages/CAJAL/lib/sample_swc.py:156: UserWarning: More disconnected segments in neuron than points to sample, skipping\n",
+      "/home/patn/CAJAL/CAJAL/lib/sample_swc.py:161: UserWarning: More disconnected segments in neuron than points to sample, skipping\n",
       "  warnings.warn(\"More disconnected segments in neuron than points to sample, skipping\")\n",
-      "/opt/conda/lib/python3.7/site-packages/CAJAL/lib/sample_swc.py:156: UserWarning: More disconnected segments in neuron than points to sample, skipping\n",
+      "/home/patn/CAJAL/CAJAL/lib/sample_swc.py:161: UserWarning: More disconnected segments in neuron than points to sample, skipping\n",
       "  warnings.warn(\"More disconnected segments in neuron than points to sample, skipping\")\n",
-      "/opt/conda/lib/python3.7/site-packages/CAJAL/lib/sample_swc.py:156: UserWarning: More disconnected segments in neuron than points to sample, skipping\n",
+      "/home/patn/CAJAL/CAJAL/lib/sample_swc.py:161: UserWarning: More disconnected segments in neuron than points to sample, skipping\n",
       "  warnings.warn(\"More disconnected segments in neuron than points to sample, skipping\")\n",
-      "/opt/conda/lib/python3.7/site-packages/CAJAL/lib/sample_swc.py:156: UserWarning: More disconnected segments in neuron than points to sample, skipping\n",
+      "/home/patn/CAJAL/CAJAL/lib/sample_swc.py:161: UserWarning: More disconnected segments in neuron than points to sample, skipping\n",
       "  warnings.warn(\"More disconnected segments in neuron than points to sample, skipping\")\n"
      ]
     },
@@ -50,7 +50,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Total time elapsed: 126.913s\n"
+      "Total time elapsed: 42.702s\n"
      ]
     }
    ],
@@ -80,7 +80,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -89,9 +89,9 @@
      "text": [
       "Calculating distances between points in each dataset\n",
       "Calculating GW distances between datasets\n",
-      "Time to compute distances: 1.332s\n",
-      "Time in GW calculation: 19.502s\n",
-      "Total time elapsed: 20.834s\n"
+      "Time to compute distances: 0.183s\n",
+      "Time in GW calculation: 6.875s\n",
+      "Total time elapsed: 7.058s\n"
      ]
     }
    ],
@@ -99,7 +99,7 @@
     "# Compute Euclidean distance on sampled points, then compute and save GW distance between cells\n",
     "t1 = time.time()\n",
     "print(\"Calculating distances between points in each dataset\")\n",
-    "dist_mat_list = run_gw.get_distances_all(data_dir=data_dir, data_prefix=data_prefix)\n",
+    "dist_mat_list = run_gw.get_intracell_distances_all(data_dir=data_dir, data_prefix=data_prefix)\n",
     "t2 = time.time()\n",
     "print(\"Calculating GW distances between datasets\")\n",
     "run_gw.save_dist_mat_preload_global(dist_mat_list, file_prefix, gw_results_dir, save_mat=True, num_cores=num_cores)\n",
@@ -118,14 +118,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Total time elapsed: 141.920s\n"
+      "Total time elapsed: 47.015s\n"
      ]
     }
    ],
@@ -141,7 +141,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -155,7 +155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -164,9 +164,9 @@
      "text": [
       "Calculating distances between points in each dataset\n",
       "Calculating GW distances between datasets\n",
-      "Time to load distances: 2.547s\n",
-      "Time in GW calculation: 19.595s\n",
-      "Total time elapsed: 22.142s\n"
+      "Time to load distances: 0.052s\n",
+      "Time in GW calculation: 5.279s\n",
+      "Total time elapsed: 5.332s\n"
      ]
     }
    ],
@@ -194,7 +194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -210,11 +210,18 @@
     "    list_dir_file.write(file_name+\"\\n\")\n",
     "list_dir_file.close()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -228,7 +235,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/notebooks/save_gw_neurons.ipynb
+++ b/notebooks/save_gw_neurons.ipynb
@@ -174,7 +174,7 @@
     "# Load geodesic distances, then compute and save GW distance between cells\n",
     "t1 = time.time()\n",
     "print(\"Calculating distances between points in each dataset\")\n",
-    "dist_mat_list = run_gw.load_distances_global(distances_dir=distances_dir, data_prefix=data_prefix)\n",
+    "dist_mat_list = run_gw.load_intracell_distances(distances_dir=distances_dir, data_prefix=data_prefix)\n",
     "t2 = time.time()\n",
     "print(\"Calculating GW distances between datasets\")\n",
     "run_gw.compute_and_save_GW_dist_mat(dist_mat_list, file_prefix, gw_results_dir, save_mat=True, num_cores=num_cores)\n",

--- a/notebooks/save_gw_obj_mesh.ipynb
+++ b/notebooks/save_gw_obj_mesh.ipynb
@@ -183,7 +183,7 @@
     "# Load geodesic distances, then compute and save GW distance between cells\n",
     "t1 = time.time()\n",
     "print(\"Calculating distances between points in each dataset\")\n",
-    "dist_mat_list = run_gw.load_distances_global(distances_dir=distances_dir, data_prefix=data_prefix)\n",
+    "dist_mat_list = run_gw.load_intracell_distances(distances_dir=distances_dir, data_prefix=data_prefix)\n",
     "\n",
     "t2 = time.time()\n",
     "print(\"Calculating GW distances between datasets\")\n",

--- a/notebooks/save_gw_obj_mesh.ipynb
+++ b/notebooks/save_gw_obj_mesh.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,14 +21,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Total time elapsed: 4.758s\n"
+      "Total time elapsed: 2.609s\n"
      ]
     }
    ],
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -51,8 +51,30 @@
     "data_dir = os.path.abspath('../CAJAL/data/sampled_pts/obj_sampled_50/')\n",
     "gw_results_dir = os.path.abspath('../CAJAL/data/gw_results')\n",
     "data_prefix = None # Not required, but helpful if another file (like python_list_dir.txt) is in same folder\n",
+    "data_suffix = \"csv\" # Not required, but helpful if another file (like python_list_dir.txt) is in same folder\n",
     "num_cores = 12\n",
     "file_prefix = \"obj_euclidean\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Calculating Euclidean distances between points in each *.obj file\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Compute Euclidean distance on sampled points, then compute and save GW distance between cells\n",
+    "t1 = time.time()\n",
+    "print(\"Calculating Euclidean distances between points in each *.obj file\")\n",
+    "dist_mat_list = run_gw.get_intracell_distances_all(data_dir=data_dir,data_prefix=data_prefix,data_suffix=data_suffix)\n",
+    "t2 = time.time()"
    ]
   },
   {
@@ -64,20 +86,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Calculating distances between points in each dataset\n",
       "Calculating GW distances between datasets\n",
-      "Time to compute distances: 0.671s\n",
-      "Time in GW calculation: 1.386s\n",
-      "Total time elapsed: 2.057s\n"
+      "Time to compute distances: 0.059s\n",
+      "Time in GW calculation: 0.931s\n",
+      "Total time elapsed: 0.990s\n"
      ]
     }
    ],
    "source": [
-    "# Compute Euclidean distance on sampled points, then compute and save GW distance between cells\n",
-    "t1 = time.time()\n",
-    "print(\"Calculating distances between points in each dataset\")\n",
-    "dist_mat_list = run_gw.get_distances_all(data_dir=data_dir, data_prefix=data_prefix)\n",
-    "t2 = time.time()\n",
     "print(\"Calculating GW distances between datasets\")\n",
     "run_gw.save_dist_mat_preload_global(dist_mat_list, file_prefix, gw_results_dir, save_mat=False, num_cores=num_cores)\n",
     "t3 = time.time()\n",
@@ -102,14 +118,31 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Total time elapsed: 8.183s\n"
+      "/home/patn/CAJAL/notebooks\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(os.getcwd())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total time elapsed: 4.748s\n"
      ]
     }
    ],
    "source": [
     "# Save geodesic network distance on sampled points from neuron reconstruction files\n",
     "start = time.time()\n",
-    "infolder = \"../CAJAL/data/OBJ_files\"\n",
+    "infolder = \"../CAJAL/data/obj_files\"\n",
     "outfolder = \"../CAJAL/data/sampled_pts/obj_geodesic_50\"\n",
     "sample_mesh.save_geodesic_from_obj_parallel(infolder, outfolder, n_sample=50, method=\"heat\", connect=False, num_cores=8)\n",
     "print('Total time elapsed: {:.3f}s'.format(time.time() - start))"
@@ -117,7 +150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,7 +164,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -140,9 +173,9 @@
      "text": [
       "Calculating distances between points in each dataset\n",
       "Calculating GW distances between datasets\n",
-      "Time to load distances: 0.921s\n",
-      "Time in GW calculation: 1.441s\n",
-      "Total time elapsed: 2.362s\n"
+      "Time to load distances: 0.019s\n",
+      "Time in GW calculation: 0.897s\n",
+      "Total time elapsed: 0.916s\n"
      ]
     }
    ],
@@ -151,6 +184,7 @@
     "t1 = time.time()\n",
     "print(\"Calculating distances between points in each dataset\")\n",
     "dist_mat_list = run_gw.load_distances_global(distances_dir=distances_dir, data_prefix=data_prefix)\n",
+    "\n",
     "t2 = time.time()\n",
     "print(\"Calculating GW distances between datasets\")\n",
     "run_gw.save_dist_mat_preload_global(dist_mat_list, file_prefix, gw_results_dir, save_mat=False, num_cores=num_cores)\n",
@@ -186,18 +220,11 @@
     "    list_dir_file.write(file_name+\"\\n\")\n",
     "list_dir_file.close()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -211,9 +238,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/save_gw_obj_mesh.ipynb
+++ b/notebooks/save_gw_obj_mesh.ipynb
@@ -28,7 +28,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Total time elapsed: 2.609s\n"
+      "Total time elapsed: 2.936s\n"
      ]
     }
    ],
@@ -87,15 +87,15 @@
      "output_type": "stream",
      "text": [
       "Calculating GW distances between datasets\n",
-      "Time to compute distances: 0.059s\n",
-      "Time in GW calculation: 0.931s\n",
-      "Total time elapsed: 0.990s\n"
+      "Time to compute distances: 0.057s\n",
+      "Time in GW calculation: 0.910s\n",
+      "Total time elapsed: 0.967s\n"
      ]
     }
    ],
    "source": [
     "print(\"Calculating GW distances between datasets\")\n",
-    "run_gw.save_dist_mat_preload_global(dist_mat_list, file_prefix, gw_results_dir, save_mat=False, num_cores=num_cores)\n",
+    "run_gw.compute_and_save_GW_dist_mat(dist_mat_list, file_prefix, gw_results_dir, save_mat=False, num_cores=num_cores)\n",
     "t3 = time.time()\n",
     "print('Time to compute distances: {:.3f}s'.format(t2 - t1))\n",
     "print('Time in GW calculation: {:.3f}s'.format(t3 - t2))\n",
@@ -135,7 +135,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Total time elapsed: 4.748s\n"
+      "Total time elapsed: 5.073s\n"
      ]
     }
    ],
@@ -173,9 +173,9 @@
      "text": [
       "Calculating distances between points in each dataset\n",
       "Calculating GW distances between datasets\n",
-      "Time to load distances: 0.019s\n",
-      "Time in GW calculation: 0.897s\n",
-      "Total time elapsed: 0.916s\n"
+      "Time to load distances: 0.021s\n",
+      "Time in GW calculation: 0.929s\n",
+      "Total time elapsed: 0.951s\n"
      ]
     }
    ],
@@ -187,7 +187,7 @@
     "\n",
     "t2 = time.time()\n",
     "print(\"Calculating GW distances between datasets\")\n",
-    "run_gw.save_dist_mat_preload_global(dist_mat_list, file_prefix, gw_results_dir, save_mat=False, num_cores=num_cores)\n",
+    "run_gw.compute_and_save_GW_dist_mat(dist_mat_list, file_prefix, gw_results_dir, save_mat=False, num_cores=num_cores)\n",
     "t3 = time.time()\n",
     "print('Time to load distances: {:.3f}s'.format(t2 - t1))\n",
     "print('Time in GW calculation: {:.3f}s'.format(t3 - t2))\n",


### PR DESCRIPTION
- Fixed error in documentation in `sample_swc.save_sample_points_parallel()`, added comments.
- Proposed renaming of `run_gw.get_distances_all()` to `get_intracell_distances_all()`, `runpy.get_distances_one()` to `get_intracell_distances_one()`. Updated tutorial notebooks and `calculate_gw_pairwise.py` to reflect this change.
- Changed the name of `run_gw.distance_matrix_preload_global()` to `compute_GW_distance_preload_global()`.  (This shows it computes the GW distance matrix, not the intracellular distance matrix) The docstring for the `compute_and_save_GW_dist_mat` function has also been updated to reflect that it computes the GW distance.
- Renamed `run_gw.save_dist_mat_preload_global()` to `compute_and_save_GW_dist_mat()`, as the new name makes it clear that
1. it does much more than just perform write-to-file operations, it actually calls the GW distance matrix computation
2. the name GW should be in the title to reflect that this is GW distance not intracellular distance
- Renamed `run_gw.load_distances_global()` to `load_intracell_distances()`.



Notebook tutorials updated appropriately.