### PR TITLE
Fix: Fixed sampling bias in cell_boundaries by excluding endpoint

### DIFF
--- a/src/cajal/sample_seg.py
+++ b/src/cajal/sample_seg.py
@@ -80,7 +80,7 @@ def cell_boundaries(
                 + " pixels around boundary of cell "
                 + str(cell)
             )
-        indices = np.linspace(0, boundary_pts.shape[0] - 1, n_sample)
+        indices = np.linspace(0, boundary_pts.shape[0] - 1, n_sample, endpoint=False)
         outlist.append((cell, boundary_pts[indices.astype("uint32")]))
     return list(outlist)
 


### PR DESCRIPTION
### Summary
This PR fixes a logic error in `src/cajal/sample_seg.py` where the start and end points of closed cell boundaries were being sampled twice, creating duplicate points

### Issue
`skimage.measure.find_contours` returns closed loops where the first and last points are identical. The previous logic used `np.linspace(..., endpoint=True)`, which sampled this geometric vertex twice

### Impact
1. **Sampling Bias:** as it creates a non-uniform distribution of points with an artificial cluster at the "seam" of the polygon, skewing GW distances
2. **Runtime Crash:**  Since both endpoints are included it results in a pairwise distance of 0.0 in the output distance matrices which breaks cajal.utilities.avg_shape because the step_size function returns 0 causing a ZeroDivisionError when the code attempts to normalize the matrix (medoid_matrix / step_size)

### The Fix
Updated the `np.linspace` call to use `endpoint=False` treating the boundary as a periodic cycle

### Verification
I verified this locally with the dataset that was previously crashing `avg_shape_spt`. The fix resolves the crash and prevents the division-by-zero error.

Closes https://github.com/CamaraLab/CAJAL/issues/20
