### PR TITLE
Fix interpolation in get_sample_pts_euclidean (swap weights)

### DIFF
--- a/src/cajal/sample_swc.py
+++ b/src/cajal/sample_swc.py
@@ -165,7 +165,7 @@ def get_sample_pts_euclidean(
                 for x in spacing:
                     sample_pts_list.append(
                         (
-                            (root_triple * x) + (child_triple * (1 - x)),
+                            (root_triple * (1 - x)) + (child_triple * x),
                             tree.root.structure_id,
                         )
                     )


### PR DESCRIPTION
This PR fixes #22. 

Thank you for developing and maintaining this great package!

This PR proposes a one-line change in `get_sample_pts_euclidean` by swapping the interpolation weights so that sampled points are placed according to their distance from the root along each edge.